### PR TITLE
API_PERSON_SEARCH_LIST: Selectively force the exact search

### DIFF
--- a/src/api_saisie_write.ml
+++ b/src/api_saisie_write.ml
@@ -107,7 +107,9 @@ let print_person_search_list conf base =
                                 :: ("exact_first_name", Adef.encoded "pfx")
                                 :: ("exact_surname", Adef.encoded "pfx")
                                 :: conf.env} in
-        if Gwdb.nb_of_real_persons base < 100_000
+        if
+          Gwdb.nb_of_real_persons base < 100_000
+          || not (Option.value ~default:true params.fast)
         then conf
         else Geneweb.AdvSearchOk.force_exact_search_by_name conf
       in

--- a/src/assets/api_saisie_write.proto
+++ b/src/assets/api_saisie_write.proto
@@ -588,6 +588,7 @@ message PersonSearchListParams {
   optional string lastname = 1;
   optional string firstname = 2;
   required int32 limit = 3;
+  optional bool fast = 4;
 }
 
 message PersonSearchList {


### PR DESCRIPTION
When the parameter `fast` is `true`.

Depends on geneweb/geneweb#2554.
